### PR TITLE
Add pytest configuration and SQL generator test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-vv"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from types import ModuleType
+
+# Add src directory to sys.path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+# Provide dummy google.generativeai module if not installed
+if 'google.generativeai' not in sys.modules:
+    google_module = ModuleType('google')
+    generativeai_module = ModuleType('google.generativeai')
+    sys.modules['google'] = google_module
+    sys.modules['google.generativeai'] = generativeai_module
+

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+from core.sql_generator import generate_sql
+
+
+def test_generate_sql_returns_cleaned_sql():
+    mock_response = """```sql
+SELECT * FROM tabela;
+```"""
+    with patch('core.sql_generator.call_llm', return_value=mock_response):
+        result = generate_sql("obter dados", "Tabela: tabela (id INT)")
+    assert result == "SELECT * FROM tabela;"
+


### PR DESCRIPTION
## Summary
- configure pytest via `pyproject.toml`
- add a test helper in `tests/__init__.py` to set up paths and mock missing `google.generativeai`
- test `generate_sql` with a mocked LLM call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ae43c02883229f2be62f3fc845e6